### PR TITLE
add default sse flag support on block PUT operation

### DIFF
--- a/src/blocks/store/s3.clj
+++ b/src/blocks/store/s3.clj
@@ -317,6 +317,13 @@
        :set-sse-flag? (boolean (:set-sse-flag? opts))})))
 
 
+(defn- parse-boolean-query-flag
+  "Presence of flag and empty or true value will return true. Anything else will return false."
+  [query-map k]
+  (boolean
+    (when-let [value (some->> k (get query-map) (str/lower-case))]
+      (or (empty? value) (= "true" value)))))
+
 (defmethod store/initialize "s3"
   [location]
   (let [uri (store/parse-uri location)]
@@ -324,6 +331,7 @@
       (:host uri)
       :prefix (:path uri)
       :region (keyword (get-in uri [:query :region]))
+      :set-sse-flag? (parse-boolean-query-flag (:query uri) :set-sse-flag)
       :credentials (when-let [creds (:user-info uri)]
                      {:access-key (:id creds)
                       :secret-key (:secret creds)}))))

--- a/src/blocks/store/s3.clj
+++ b/src/blocks/store/s3.clj
@@ -77,8 +77,10 @@
       (.setRegion client region))
     client))
 
+
 (def ^:private sse-algorithms
   {:aes-256 ObjectMetadata/AES_256_SERVER_SIDE_ENCRYPTION})
+
 
 (defn select-sse-algorithm
   [algorithm]
@@ -276,7 +278,6 @@
           (.setPrefix (:prefix store)))))))
 
 
-
 ;; ## Store Construction
 
 (store/privatize-constructors! S3BlockStore)
@@ -309,8 +310,8 @@
     explicit AWS credentials.
   - `:region` a keyword or string designating the region the bucket is in.
   - `:prefix` a string prefix to store the blocks under.
-  - `:sse-algorithm` a keyword algorithm selection to set Server Side Encryption
-    on block PUT. No `:sse-algorithm` present will not set this flag."
+  - `:sse` a keyword algorithm selection to set Server Side Encryption
+    on block PUT. No `:sse` present will not set this flag."
   [bucket & {:as opts}]
   (when (or (not (string? bucket))
             (empty? (str/trim bucket)))
@@ -323,7 +324,7 @@
       {:client (get-client opts)
        :bucket (str/trim bucket)
        :prefix (some-> (trim-slashes (:prefix opts)) (str "/"))
-       :sse-algorithm (:sse-algorithm opts)})))
+       :sse (:sse opts)})))
 
 
 (defmethod store/initialize "s3"
@@ -333,8 +334,8 @@
       (:host uri)
       :prefix (:path uri)
       :region (keyword (get-in uri [:query :region]))
-      :sse-algorithm (when-let [algorithm (keyword (get-in uri [:query :sse-algorithm]))]
-                  (select-sse-algorithm algorithm))
+      :sse (when-let [algorithm (keyword (get-in uri [:query :sse]))]
+             (select-sse-algorithm algorithm))
       :credentials (when-let [creds (:user-info uri)]
                      {:access-key (:id creds)
                       :secret-key (:secret creds)}))))

--- a/src/blocks/store/s3.clj
+++ b/src/blocks/store/s3.clj
@@ -277,6 +277,7 @@
           (.setPrefix (:prefix store)))))))
 
 
+
 ;; ## Store Construction
 
 (store/privatize-constructors! S3BlockStore)
@@ -300,7 +301,6 @@
   "Creates a new S3 block store. If credentials are not explicitly provided, the
   AWS SDK will use a number of mechanisms to infer them from the environment.
 
-
   Supported options:
 
   - `:credentials` a map with `:access-key` and `:secret-key` entries providing
@@ -323,9 +323,7 @@
       (dissoc opts :credentials)
       {:client (get-client opts)
        :bucket (str/trim bucket)
-       :prefix (some-> (trim-slashes (:prefix opts)) (str "/"))
-       :sse (:sse opts)
-       :alter-put-metadata (:alter-put-metadata opts)})))
+       :prefix (some-> (trim-slashes (:prefix opts)) (str "/"))})))
 
 
 (defmethod store/initialize "s3"

--- a/test/blocks/store/s3_test.clj
+++ b/test/blocks/store/s3_test.clj
@@ -197,13 +197,15 @@
   (is (= "bar/" (:prefix (s3-block-store "foo-bucket" :prefix "bar/")))))
 
 
-(deftest query-flag-parsing
-  (is (not (#'s3/parse-boolean-query-flag {} nil)))
-  (is (not (#'s3/parse-boolean-query-flag {} :a)))
-  (is (#'s3/parse-boolean-query-flag {:a "true"} :a))
-  (is (not (#'s3/parse-boolean-query-flag {:a "false"} :a)))
-  (is (#'s3/parse-boolean-query-flag {:a ""} :a))
-  (is (not (#'s3/parse-boolean-query-flag {:a "true" :b "false"} :b))))
+(deftest sse-algorithm-selection
+  (is (thrown? Exception
+               (s3/select-sse-algorithm nil)))
+  (is (thrown? Exception
+               (s3/select-sse-algorithm :foo/bar)))
+  (is (= ObjectMetadata/AES_256_SERVER_SIDE_ENCRYPTION
+         (s3/select-sse-algorithm :aes-256))))
+
+
 
 ;; ## Integration Tests
 

--- a/test/blocks/store/s3_test.clj
+++ b/test/blocks/store/s3_test.clj
@@ -199,11 +199,11 @@
 
 (deftest sse-algorithm-selection
   (is (thrown? Exception
-        (s3/select-sse-algorithm nil)))
+               (#'s3/select-sse-algorithm nil)))
   (is (thrown? Exception
-        (s3/select-sse-algorithm :foo/bar)))
+               (#'s3/select-sse-algorithm :foo/bar)))
   (is (= ObjectMetadata/AES_256_SERVER_SIDE_ENCRYPTION
-         (s3/select-sse-algorithm :aes-256))))
+         (#'s3/select-sse-algorithm :aes-256))))
 
 
 ;; ## Integration Tests

--- a/test/blocks/store/s3_test.clj
+++ b/test/blocks/store/s3_test.clj
@@ -197,6 +197,13 @@
   (is (= "bar/" (:prefix (s3-block-store "foo-bucket" :prefix "bar/")))))
 
 
+(deftest query-flag-parsing
+  (is (not (#'s3/parse-boolean-query-flag {} nil)))
+  (is (not (#'s3/parse-boolean-query-flag {} :a)))
+  (is (#'s3/parse-boolean-query-flag {:a "true"} :a))
+  (is (not (#'s3/parse-boolean-query-flag {:a "false"} :a)))
+  (is (#'s3/parse-boolean-query-flag {:a ""} :a))
+  (is (not (#'s3/parse-boolean-query-flag {:a "true" :b "false"} :b))))
 
 ;; ## Integration Tests
 

--- a/test/blocks/store/s3_test.clj
+++ b/test/blocks/store/s3_test.clj
@@ -199,12 +199,11 @@
 
 (deftest sse-algorithm-selection
   (is (thrown? Exception
-               (s3/select-sse-algorithm nil)))
+        (s3/select-sse-algorithm nil)))
   (is (thrown? Exception
-               (s3/select-sse-algorithm :foo/bar)))
+        (s3/select-sse-algorithm :foo/bar)))
   (is (= ObjectMetadata/AES_256_SERVER_SIDE_ENCRYPTION
          (s3/select-sse-algorithm :aes-256))))
-
 
 
 ;; ## Integration Tests


### PR DESCRIPTION
Need this for a policy update to my buckets where I need to ensure SSE is set when storing blocks.

This flag setting is transparent to any other client GET/LIST but simply makes s3 encrypt the data at rest in s3 storage.